### PR TITLE
Generalize 'progress' event to send messages back from workers

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -348,6 +348,19 @@ Job.prototype.progress = function (complete, total) {
 };
 
 /**
+ * Allows custom message types to be sent by
+ * a job.
+ *
+ * @param {String} event
+ * @param {Mixed} message data
+ * @api public
+ */
+
+Job.prototype.send = function (event, data) {
+    events.emit(this.id, event, data);
+}
+
+/**
  * Set the job delay in `ms`.
  *
  * @param {Number} ms

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1,3 +1,4 @@
+assert = require 'assert'
 kue = require '../'
 jobs = kue.createQueue()
 Job = kue.Job
@@ -26,6 +27,22 @@ describe 'Kue', ->
       jobs.create('email-to-be-completed', job_data)
       .on 'complete', ->
           done()
+      .save()
+
+    it 'should handle custom events', (done) ->
+      jobdata = {pt: null};
+      jobs.process 'email-with-custom-event', (job, done) ->
+        job.send("result", {processingTime: 120})
+        done()
+      job_data =
+        title: 'Test Email Job'
+        to: 'tj@learnboost.com'
+      jobs.create('email-with-custom-event', job_data)
+      .on 'result', (obj) ->
+        jobdata.pt = obj.processingTime
+      .on 'complete', ->
+        assert.equal(jobdata.pt, 120);
+        done()
       .save()
 
 


### PR DESCRIPTION
This simple modification allows workers to transmit custom messages back to the initiator of a job request.  This allows the results of jobs to be returned to the requester (see test case).  But it has other potential uses such as transmitting status updates.

The key point here is to leverage the existing message queue that kue already provides for things like complete, failure and progress messages and open it up so it can be used to send other information as well.