### PR TITLE
Change JSON API sorting criteria

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -354,7 +354,7 @@ Get job `:id`'s log:
 
 ### GET /jobs/:from..:to/:order?
 
-Get jobs with the specified range `:from` to `:to`, for example "/jobs/0..2", where `:order` may be "asc" or "desc":
+Get jobs with the specified range `:from` to `:to`, for example "/jobs/0..2", where `:order` may be "asc", "desc", "byId:asc" or "byId:desc":
 
 ```js
 [{"id":"12","type":"email","data":{"title":"welcome email for tj","to":"tj@learnboost.com","template":"welcome-email"},"priority":-10,"progress":0,"state":"active","attempts":null,"created_at":"1309973299293","updated_at":"1309973299293"},{"id":"130","type":"email","data":{"title":"welcome email for tj","to":"tj@learnboost.com","template":"welcome-email"},"priority":-10,"progress":0,"state":"active","attempts":null,"created_at":"1309975157291","updated_at":"1309975157291"}]

--- a/lib/http/views/_sort.jade
+++ b/lib/http/views/_sort.jade
@@ -2,3 +2,5 @@ select#sort
     option(value='asc') sort
     option(value='asc') asc
     option(value='desc') desc
+    option(value='byId:asc') asc by id
+    option(value='byId:desc') desc by id

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -104,7 +104,12 @@ function get(fn, order) {
  */
 
 exports.range = function (from, to, order, fn) {
-  redis.client().zrange('q:jobs', from, to, get(fn, order));
+  if (/^byId:(desc|asc)$/.test(order)) {
+    order = order.replace('byId:', '');
+    redis.client().sort('q:jobs', 'LIMIT', from, to, order, get(fn, order));
+  } else {
+    redis.client().zrange('q:jobs', from, to, get(fn, order));
+  }
 };
 
 /**
@@ -120,7 +125,12 @@ exports.range = function (from, to, order, fn) {
  */
 
 exports.rangeByState = function (state, from, to, order, fn) {
-  redis.client().zrange('q:jobs:' + state, from, to, get(fn, order));
+  if (/^byId:(desc|asc)$/.test(order)) {
+    order = order.replace('byId:', '');
+    redis.client().sort('q:jobs:' + state, 'LIMIT', from, to, order, get(fn, order));
+  } else {
+    redis.client().zrange('q:jobs:' + state, from, to, get(fn, order));
+  }
 };
 
 /**
@@ -137,7 +147,12 @@ exports.rangeByState = function (state, from, to, order, fn) {
  */
 
 exports.rangeByType = function (type, state, from, to, order, fn) {
-  redis.client().zrange('q:jobs:' + type + ':' + state, from, to, get(fn, order));
+  if (/^byId:(desc|asc)$/.test(order)) {
+    order = order.replace('byId:', '');
+    redis.client().sort('q:jobs:' + type + ':' + state, 'LIMIT', from, to, order, get(fn, order));
+  } else {
+    redis.client().zrange('q:jobs:' + type + ':' + state, from, to, get(fn, order));
+  }
 };
 
 /**


### PR DESCRIPTION
This patch is for #33, #113 and #131.

Criteria from priotiry changed to id
* Use redis SORT instead of ZRANGE
* Remove sorting in map function

Currently, the web ui still not work correctly when it comes newer jobs. I will make another patch for that.