### PR TITLE
Allow to pass data with progress

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -369,12 +369,12 @@ Job.prototype.get = function (key, fn) {
  * @api public
  */
 
-Job.prototype.progress = function (complete, total) {
+Job.prototype.progress = function (complete, total, data) {
     if (0 == arguments.length) return this._progress;
     var n = Math.min(100, complete / total * 100 | 0);
     this.set('progress', n);
     this.set('updated_at', Date.now());
-    events.emit(this.id, 'progress', n);
+    events.emit(this.id, 'progress', n, JSON.stringify(data));
     return this;
 };
 


### PR DESCRIPTION
This should solve LearnBoost/kue#313 in a backwards compatible way - at least for me its enough.

So one can do:

```
job.on('progress', function onJobProgress (progress, data) {
  // do something - data will be available as string if passed
});
```