### PR TITLE
delay() can now accept a future date at which run the job

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -381,14 +381,19 @@ Job.prototype.progress = function (complete, total) {
 /**
  * Set the job delay in `ms`.
  *
- * @param {Number} ms
+ * @param {Number|Date} delay in ms or execution date
  * @return {Job|Number}
  * @api public
  */
 
 Job.prototype.delay = function (ms) {
     if (0 == arguments.length) return this._delay;
-    this._delay = ms;
+    if(_.isDate(ms)) {
+        ms = parseInt(ms.getTime() - Date.now())
+    }
+    if(ms > 0) {
+        this._delay = ms;
+    }
 //    this._state = 'delayed';
     return this;
 };

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -100,11 +100,21 @@ describe 'Kue Tests', ->
   describe 'Job', ->
     it 'should be processed after delay', (done) ->
       now = Date.now()
-      jobs.create( 'simple-delayed-job', { title: 'simple delay job' } ).delay(300).save()
-      jobs.process 'simple-delayed-job', (job, jdone) ->
+      jobs.create( 'future-job', { title: 'simple delay job' } ).delay(300).save()
+      jobs.process 'future-job', (job, jdone) ->
         processed = Date.now()
         (processed - now).should.be.greaterThan( 300 )
         (processed - now).should.be.lessThan( 500 )
+        jdone()
+        done()
+
+    it 'should be processed at a future date', (done) ->
+      now = Date.now()
+      jobs.create( 'future-job', { title: 'future job' } ).delay(new Date(now + 500)).save()
+      jobs.process 'future-job', (job, jdone) ->
+        processed = Date.now()
+        (processed - now).should.be.greaterThan( 500 )
+        (processed - now).should.be.lessThan( 700 )
         jdone()
         done()
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -100,8 +100,8 @@ describe 'Kue Tests', ->
   describe 'Job', ->
     it 'should be processed after delay', (done) ->
       now = Date.now()
-      jobs.create( 'future-job', { title: 'simple delay job' } ).delay(300).save()
-      jobs.process 'future-job', (job, jdone) ->
+      jobs.create( 'simple-delay-job', { title: 'simple delay job' } ).delay(300).save()
+      jobs.process 'simple-delay-job', (job, jdone) ->
         processed = Date.now()
         (processed - now).should.be.greaterThan( 300 )
         (processed - now).should.be.lessThan( 500 )


### PR DESCRIPTION
It's now possible to pass a Date object to delay() with a future date in time instead of a number of ms.