### PR TITLE
POST /job can now accept an array of jobs

### DIFF
--- a/lib/http/routes/json.js
+++ b/lib/http/routes/json.js
@@ -11,6 +11,7 @@
 var Queue = require('../../kue')
     , Job = require('../../queue/job')
     , reds = require('reds')
+    , lodash = require('lodash')
     , queue = Queue.createQueue();
 
 /**
@@ -141,21 +142,62 @@ exports.job = function (req, res) {
 exports.createJob = function (req, res) {
     var body = req.body;
 
-    if (!body.type) return res.send({ error: 'Must provide job type' }, 400);
+    function _create(args, next) {
+        if (!args.type) return next({ error: 'Must provide job type' }, null, 400);
 
-    var job = new Job(body.type, body.data || {});
-    var options = body.options || {};
-    if (options.attempts) job.attempts(parseInt(options.attempts));
-    if (options.priority) job.priority(options.priority);
-    if (options.delay) job.delay(options.delay);
-    if (options.searchKeys) job.searchKeys(options.searchKeys);
-    if (options.backoff) job.backoff(options.backoff);
-    if (options.removeOnComplete) job.removeOnComplete(options.removeOnComplete);
+        var job = new Job(args.type, args.data || {});
+        var options = args.options || {};
+        if (options.attempts) job.attempts(parseInt(options.attempts));
+        if (options.priority) job.priority(options.priority);
+        if (options.delay) job.delay(options.delay);
+        if (options.searchKeys) job.searchKeys(options.searchKeys);
+        if (options.backoff) job.backoff(options.backoff);
+        if (options.removeOnComplete) job.removeOnComplete(options.removeOnComplete);
 
-    job.save(function (err) {
-        if (err) return res.send({ error: err.message }, 500);
-        res.send({ message: 'job created', id: job.id });
-    });
+        job.save(function (err) {
+            if (err) {
+                return next({ error: err.message }, null, 500);
+            }
+            else {
+                return next(null, { message: 'job created', id: job.id });
+            }
+        });
+    }
+
+    if (body) {
+        if (lodash.isArray(body)) {
+            var i = 0, len = body.length;
+            var result = [];
+            -function _iterate() {
+                _create(body[i], function(err, status, errCode) {
+                    result.push(err || status);
+                    if (err) {
+                        res.send(result, errCode || 500);
+                    }
+                    else {
+                        i++;
+                        if (i < len) {
+                            _iterate();
+                        }
+                        else {
+                            res.send(result);
+                        }
+                    }
+                    
+                })
+            }()
+        }
+        else {
+            _create(body, function(err, status, errCode) {
+                if (err) {
+                    res.send(err, errCode || 500);
+                }
+                else {
+                    res.send(status);
+                }
+            })
+        }
+    }
 };
 
 /**


### PR DESCRIPTION
POST /job can now accept an array of jobs. The format is as you would expect:

````
$ curl -H "Content-Type: application/json" -X POST -d     '[{
       "type": "email",
       "data": {
         "title": "welcome email for tj",
         "to": "tj@learnboost.com",
         "template": "welcome-email"
       },
       "options" : {
         "attempts": 5,
         "priority": "high"
       }
     },
     {
       "type": "",
       "data": {
         "title": "welcome email for tj",
         "to": "tj@learnboost.com",
         "template": "welcome-email"
       },
       "options" : {
         "attempts": 5,
         "priority": "high"
       }
     }]' http://localhost:3000/job

# Response: (status code: 400)
[
  {
    "message": "job created",
    "id": 772
  },
  {
    "error": "Must provide job type"
  }
]
````

Some notes:

1. If only an object is provided, the behaviour is exactly like before
2. If an array is provided, the response is an array with the response from each job creation, in the same order as the request array.
3. In case of error, previous successes are reported. The last element of the array is an error object, and no more jobs are scheduled.