### PR TITLE
Add promote_at functionality. Also optimized logic for promotion 

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -140,7 +140,7 @@ Queue.prototype.promote = function (ms, l) {
     clearInterval(this.promoter);
     this.promoter = setInterval(function () {
         client.sort(client.getKey('jobs:delayed')
-            , 'by', client.getKey('job:*->delay')
+            , 'by', client.getKey('job:*->promote_at')
             , 'get', '#'
             , 'get', client.getKey('job:*->delay')
             , 'get', client.getKey('job:*->created_at')

--- a/lib/kue.js
+++ b/lib/kue.js
@@ -133,39 +133,35 @@ Queue.prototype.on = function (event) {
  */
 
 Queue.prototype.promote = function (ms, l) {
-    var client = this.client
-        , ms = ms || 5000
-        , limit = l || 200;
+  var client = this.client
+    , ms = ms || 5000
+    , limit = l || 200;
 
-    clearInterval(this.promoter);
-    this.promoter = setInterval(function () {
-        client.sort(client.getKey('jobs:delayed')
-            , 'by', client.getKey('job:*->promote_at')
-            , 'get', '#'
-            , 'get', client.getKey('job:*->promote_at')
-            , 'limit', 0, limit, function (err, jobs) {
-                if (err || !jobs.length) return;
+  clearInterval(this.promoter);
+  this.promoter = setInterval(function () {
+    client.zrange(client.getKey('jobs:delayed_promotion'),
+      0, limit-1, 'WITHSCORES', function (err, results) {
+        if (err || !results.length) return;
 
-                // iterate jobs with [id, delay, created_at]
-                while (jobs.length) {
-                    var job = jobs.slice(0, 2)
-                        , id = parseInt(job[0], 10)
-                        , promote_at = parseInt(job[1], 10);
-                    // if it's due for activity
-                    // "promote" the job by marking
-                    // it as inactive.
-                    if (promote_at < Date.now()) {
-                        Job.get(id, function (err, job) {
-                            if (err) return;
-                            events.emit(id, 'promotion');
-                            job.inactive();
-                        });
-                    }
-
-                    jobs = jobs.slice(2);
-                }
+        // iterate jobs with [id, delay, created_at]
+        while (results.length && results[0] && results[1]) {
+          var id = parseInt(results[0], 10)
+            , promote_at = parseInt(results[1], 10)
+            , promote = !Math.max(promote_at - Date.now(), 0);
+          // if it's due for activity
+          // "promote" the job by marking
+          // it as inactive.
+          if (promote) {
+            Job.get(id, function (err, job) {
+              if (err) return;
+              events.emit(id, 'promotion');
+              job.inactive();
             });
-    }, ms);
+          }
+          results = results.slice(2);
+        }
+      });
+  }, ms);
 };
 
 Queue.prototype.watchStuckJobs = function (ms) {

--- a/lib/kue.js
+++ b/lib/kue.js
@@ -142,24 +142,19 @@ Queue.prototype.promote = function (ms, l) {
         client.sort(client.getKey('jobs:delayed')
             , 'by', client.getKey('job:*->promote_at')
             , 'get', '#'
-            , 'get', client.getKey('job:*->delay')
-            , 'get', client.getKey('job:*->created_at')
-            , 'get', client.getKey('job:*->failed_at')
+            , 'get', client.getKey('job:*->promote_at')
             , 'limit', 0, limit, function (err, jobs) {
                 if (err || !jobs.length) return;
 
                 // iterate jobs with [id, delay, created_at]
                 while (jobs.length) {
-                    var job = jobs.slice(0, 4)
+                    var job = jobs.slice(0, 2)
                         , id = parseInt(job[0], 10)
-                        , delay = parseInt(job[1], 10)
-                        , creation = parseInt(job[2], 10)
-                        , failed_at = parseInt(job[3], 10)
-                        , promote = !Math.max((failed_at||creation) + delay - Date.now(), 0);
+                        , promote_at = parseInt(job[1], 10);
                     // if it's due for activity
                     // "promote" the job by marking
                     // it as inactive.
-                    if (promote) {
+                    if (promote_at < Date.now()) {
                         Job.get(id, function (err, job) {
                             if (err) return;
                             events.emit(id, 'promotion');
@@ -167,7 +162,7 @@ Queue.prototype.promote = function (ms, l) {
                         });
                     }
 
-                    jobs = jobs.slice(4);
+                    jobs = jobs.slice(2);
                 }
             });
     }, ms);

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -552,7 +552,7 @@ Job.prototype.state = function (state, fn) {
         .zadd(client.getKey('jobs:' + this.type + ':' + state), this._priority, this.id);
 
     // Add job id to delayed_promotion set and use promote_at as score when job moves to delayed
-    ('delayed' == state) ? multi.zadd(client.getKey('jobs:delayed_promotion'), this.promote_at,this.id) : noop();
+    ('delayed' == state) ? multi.zadd(client.getKey('jobs:delayed_promotion'), parseInt(this._promote_at),this.id) : noop();
 
     ('inactive' == state) ? multi.lpush(client.getKey(this.type + ':jobs'), 1) : noop();
 
@@ -665,7 +665,10 @@ Job.prototype.save = function (fn) {
             if (max) client.hset(key, 'max_attempts', max);
             client.sadd(client.getKey('job:types'), self.type);
             self.set('type', self.type);
-            self.set('created_at', Date.now());
+            var created_at=Date.now();
+            self._promote_at=created_at + self._delay;
+            self.set('created_at', created_at);
+            self.set('promote_at', self._promote_at);
             self.update(fn);
         }.bind(this));
     }.bind(this));
@@ -693,12 +696,11 @@ Job.prototype.update = function (fn) {
     // delay
     if (this._delay) {
         this.set('delay', this._delay);
-
         if ( this.created_at ) {
             var timestamp = parseInt(this.failed_at||this.created_at, 10)
                 , delay = parseInt(this._delay);
-            
-            this.set('promote_at', timestamp + delay);
+          this._promote_at=timestamp + delay;
+          this.set('promote_at', this._promote_at);
         }
     }
 

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -173,6 +173,7 @@ exports.get = function (id, fn) {
         job._state = hash.state;
         job._error = hash.error;
         job.created_at = hash.created_at;
+        job.promote_at = hash.promote_at;
         job.updated_at = hash.updated_at;
         job.failed_at = hash.failed_at;
         job.duration = hash.duration;
@@ -284,6 +285,7 @@ Job.prototype.toJSON = function () {
         , failed_at: this.failed_at
         , duration: this.duration
         , delay: this._delay
+        , promote_at: this.promote_at
         , attempts: {
             made: Number(this._attempts) || 0
           , remaining: this._attempts ? this._max_attempts - this._attempts : Number(this._max_attempts)||1
@@ -602,7 +604,8 @@ Job.prototype.complete = function (clbk) {
  */
 
 Job.prototype.failed = function (clbk) {
-    return this.set('failed_at', Date.now()).state('failed', clbk);
+    this.failed_at = Date.now();
+    return this.set('failed_at', this.failed_at).state('failed', clbk);
 };
 
 /**
@@ -658,6 +661,7 @@ Job.prototype.save = function (fn) {
             client.sadd(client.getKey('job:types'), self.type);
             self.set('type', self.type);
             self.set('created_at', Date.now());
+            self.set('promote_at', Date.now() + self._delay);
             self.update(fn);
         }.bind(this));
     }.bind(this));
@@ -683,7 +687,11 @@ Job.prototype.update = function (fn) {
     }
 
     // delay
-    if (this._delay) this.set('delay', this._delay);
+    if (this._delay) {
+        this.set('delay', this._delay);
+        this.set('promote_at', (this.failed_at||this.created_at||Date.now()) * 1 + this._delay);
+    }
+
     if (this._removeOnComplete) this.set('removeOnComplete', this._removeOnComplete);
 
     if (this._backoff) {

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -689,7 +689,13 @@ Job.prototype.update = function (fn) {
     // delay
     if (this._delay) {
         this.set('delay', this._delay);
-        this.set('promote_at', (this.failed_at||this.created_at||Date.now()) * 1 + this._delay);
+
+        if ( this.created_at ) {
+            var timestamp = parseInt(this.failed_at||this.created_at, 10)
+                , delay = parseInt(this._delay);
+            
+            this.set('promote_at', timestamp + delay);
+        }
     }
 
     if (this._removeOnComplete) this.set('removeOnComplete', this._removeOnComplete);

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -202,6 +202,7 @@ exports.removeBadJob = function (id) {
         .zrem(client.getKey('jobs:active'), id)
         .zrem(client.getKey('jobs:complete'), id)
         .zrem(client.getKey('jobs:failed'), id)
+        .zrem(client.getKey('jobs:delayed_promotion'), id)
         .zrem(client.getKey('jobs'), id)
     .exec();
     if( !exports.disableSearch ){
@@ -512,7 +513,6 @@ Job.prototype.remove = function (fn) {
         .zrem(client.getKey('jobs:' + this.state()), this.id)
         .zrem(client.getKey('jobs:' + this.type + ':' + this.state()), this.id)
         .zrem(client.getKey('jobs'), this.id)
-        .zrem(client.getKey('jobs:delayed_promotion'), this.id)
         .del(client.getKey('job:' + this.id + ':log'))
         .del(client.getKey('job:' + this.id))
         .exec( function( err ){

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -543,11 +543,16 @@ Job.prototype.state = function (state, fn) {
         multi
             .zrem(client.getKey('jobs:' + oldState), this.id)
             .zrem(client.getKey('jobs:' + this.type + ':' + oldState), this.id);
+        // Remove job id from delayed_promotion set when job moves away from delayed
+        ('delayed' == oldState) ? multi.zrem(client.getKey('jobs:delayed_promotion'), this.id) : noop();
     }
     multi
         .hset(client.getKey('job:' + this.id), 'state', state)
         .zadd(client.getKey('jobs:' + state), this._priority, this.id)
         .zadd(client.getKey('jobs:' + this.type + ':' + state), this._priority, this.id);
+
+    // Add job id to delayed_promotion set and use promote_at as score when job moves to delayed
+    ('delayed' == state) ? multi.zadd(client.getKey('jobs:delayed_promotion'), this.promote_at,this.id) : noop();
 
     ('inactive' == state) ? multi.lpush(client.getKey(this.type + ':jobs'), 1) : noop();
 
@@ -661,7 +666,6 @@ Job.prototype.save = function (fn) {
             client.sadd(client.getKey('job:types'), self.type);
             self.set('type', self.type);
             self.set('created_at', Date.now());
-            self.set('promote_at', Date.now() + self._delay);
             self.update(fn);
         }.bind(this));
     }.bind(this));

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -512,6 +512,7 @@ Job.prototype.remove = function (fn) {
         .zrem(client.getKey('jobs:' + this.state()), this.id)
         .zrem(client.getKey('jobs:' + this.type + ':' + this.state()), this.id)
         .zrem(client.getKey('jobs'), this.id)
+        .zrem(client.getKey('jobs:delayed_promotion'), this.id)
         .del(client.getKey('job:' + this.id + ':log'))
         .del(client.getKey('job:' + this.id))
         .exec( function( err ){
@@ -666,7 +667,7 @@ Job.prototype.save = function (fn) {
             client.sadd(client.getKey('job:types'), self.type);
             self.set('type', self.type);
             var created_at=Date.now();
-            self._promote_at=created_at + self._delay;
+            self._promote_at=created_at + (self._delay||0);
             self.set('created_at', created_at);
             self.set('promote_at', self._promote_at);
             self.update(fn);


### PR DESCRIPTION
We were facing two issues: 
1. Long delayed jobs were never promoted(https://github.com/LearnBoost/kue/issues/312)
2. Number of delayed jobs were more than 9 lakhs and increasing. When promotion code executed(at an interval of 5 sec), redis took atleast 1.5 sec just to sort them.

To fix above two issues, this pull request did following: 
1. Additionally save promote_at field which is based on delay and creation time
2. Create a new zset 'q:jobs:delayed_promotion' which stores job id along with promote_at timestamp(as score)
3. When job.promote is called, first n(where n is limit passed to promote function) number of jobs are fetched from 'q:jobs:delayed_promotion' and moved to inactive. Since 'q:jobs:delayed_promotion'  already sorted based on promote_at timestamp, it took few ms to get them
