### PR TITLE
add feature to specify redis connection string when making a Queue

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -342,6 +342,14 @@ var q = kue.createQueue({
 
 `prefix` controls the key names used in Redis.  By default, this is simply `q`. Prefix generally shouldn't be changed unless you need to use one Redis instance for multiple apps. It can also be useful for providing an isolated testbed across your main application.
 
+You can also specify the connection information as a URL string.
+
+```js
+var q = kue.createQueue({
+  redis: 'redis://example.com:1234?redis_option=value&redis_option=value'
+});
+```
+
 #### Connecting using Unix Domain Sockets
 
 Since [node_redis](https://github.com/mranney/node_redis) supports Unix Domain Sockets, you can also tell Kue to do so. See [unix-domain-socket](https://github.com/mranney/node_redis#unix-domain-socket) for your redis server configuration.

--- a/Readme.md
+++ b/Readme.md
@@ -334,7 +334,7 @@ var q = kue.createQueue({
     auth: 'password',
     db: 3, // if provided select a non-default redis db
     options: {
-      // see https://github.com/mranney/node_redis#rediscreateclientport-host-options
+      // see https://github.com/mranney/node_redis#rediscreateclient
     }
   }
 });

--- a/lib/kue.js
+++ b/lib/kue.js
@@ -84,7 +84,6 @@ exports.workers = [];
 function Queue( options ) {
     options = options || {};
     redis.configureFactory( options, this );
-//    console.log( "******************** creating Kue client... " );
     this.client = Worker.client = Job.client = redis.createClient();
     this.promoter = null;
     this.workers = exports.workers;

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -10,6 +10,7 @@
  */
 
 var redis = require('redis');
+var url = require('url');
 
 /**
  *
@@ -17,6 +18,23 @@ var redis = require('redis');
  */
 exports.configureFactory = function( options, queue ) {
     options.prefix = options.prefix || 'q';
+
+    if (typeof options.redis === 'string') {
+        // parse the url
+        var conn_info = url.parse(options.redis, true /* parse query string */);
+        if (conn_info.protocol !== 'redis:') {
+            throw new Error('kue connection string must use the redis: protocol');
+        }
+
+        options.redis = {
+            port: conn_info.port || 6379,
+            host: conn_info.hostname,
+            auth: conn_info.auth,
+            // see https://github.com/mranney/node_redis#rediscreateclient
+            options: conn_info.query
+        };
+    }
+
     options.redis = options.redis || {};
 
     // guarantee that redis._client has not been populated.

--- a/test/test.js
+++ b/test/test.js
@@ -11,10 +11,7 @@ describe('Jobs', function () {
     });
 
     afterEach(function (done) {
-//        jobs.shutdown( function( err ){
-//          jobs = null;
           done();
-//        }, 500 );
     });
 
     it('should be processed', function (done) {
@@ -52,6 +49,29 @@ describe('Jobs', function () {
                 done();
             else
                 done(new Error("error"));
+        });
+    });
+
+    it('should accept url strings for redis when making an new queue', function (done) {
+        var jobs = new kue({
+            redis: 'redis://localhost:6379/?foo=bar'
+        });
+
+        jobs.client.connectionOption.port.should.be.eql(6379);
+        jobs.client.connectionOption.host.should.be.eql('localhost');
+        jobs.client.options.foo.should.be.eql('bar');
+
+        var jobData = {
+            title: 'welcome email for tj',
+            to: '"TJ" <tj@learnboost.com>',
+            template: 'welcome-email'
+        };
+        jobs.create('email-should-be-processed-2', jobData).priority('high').save();
+        jobs.process('email-should-be-processed-2', function (job, jdone) {
+            job.data.should.be.eql(jobData);
+            job.log( '<p>This is <span style="color: green;">a</span> formatted log<p/>' );
+            jdone();
+            done();
         });
     });
 


### PR DESCRIPTION
User can specify a redis connection url when creating a new queue by
using the `redis` option and providing a string instead of an object.